### PR TITLE
cutting issue fixed

### DIFF
--- a/moving_sphere.h
+++ b/moving_sphere.h
@@ -59,7 +59,7 @@ bool moving_sphere::hit(const ray& r, float t_min, float t_max, hit_record& rec)
 bool moving_sphere::bounding_box(float t0, float t1, aabb& box) const {
     vec3 min_center = min(center(t0), center(t1));
     vec3 max_center = max(center(t0), center(t1));
-    float r = abs(radius);
+    float r = fabs(radius);
     box = aabb(min_center - r, max_center + r);
     return true;
 }

--- a/sphere.h
+++ b/sphere.h
@@ -56,7 +56,7 @@ bool sphere::hit(const ray& r, float t_min, float t_max, hit_record& rec) const 
 }
 
 bool sphere::bounding_box(float t0, float t1, aabb& box) const {
-    float r = abs(radius);
+    float r = fabs(radius);
     box = aabb(center - r, center + r);
     return true;
 }


### PR DESCRIPTION
fixed the issue that small balls with fractional radius might be cut in the rendered results, which is due to the fact that, when determining the bounding box for spheres, the method `abs()` for integers was used instead of `fabs()` for floats.